### PR TITLE
An even shorter version

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -5,7 +5,7 @@
       configurable: true,
       get: function () {
         this.globalThis = this;
-        delete Object.prototype._T_;
+        delete this._T_;
       }
     }), _T_);
 }(Object));

--- a/esm/index.js
+++ b/esm/index.js
@@ -5,7 +5,7 @@
       configurable: true,
       get: function () {
         this.globalThis = this;
-        delete Object.prototype._T_;
+        delete this._T_;
       }
     }), _T_);
 }(Object));

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
+// inspired by https://mathiasbynens.be/notes/globalthis
 (function (Object) {
   if (typeof globalThis === 'undefined')
     (Object.defineProperty(Object.prototype, '_T_', {
       configurable: true,
       get: function () {
         this.globalThis = this;
-        delete Object.prototype._T_;
+        delete this._T_;
       }
     }), _T_);
 }(Object));

--- a/min.js
+++ b/min.js
@@ -1,1 +1,1 @@
-!function(e){"undefined"==typeof globalThis&&(e.defineProperty(e.prototype,"_T_",{configurable:!0,get:function(){this.globalThis=this,delete e.prototype._T_}}),_T_)}(Object);
+!function(e){"undefined"==typeof globalThis&&(e.defineProperty(e.prototype,"_T_",{configurable:!0,get:function(){delete(this.globalThis=this)._T_}}),_T_)}(Object);


### PR DESCRIPTION
`delete this._T_` correctly propagates through prototypes until it finds a property to delete, so this deletes a temporary property on Object.prototype.