### PR TITLE
fix: Make `globalThis` non‑enumerable

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,15 +1,31 @@
 (function (Object) {
+  var $ObjectPrototype = Object.prototype,
+    $defineGetter = $ObjectPrototype.__defineGetter__,
+    $defineProperty =
+      Object.defineProperty ||
+      function defineProperty(obj, prop, desc) {
+        if (desc.value) {
+          obj[prop] = desc.value;
+        } else if (desc.get) {
+          $defineGetter.call(obj, prop, desc.get);
+        }
+      };
   typeof globalThis !== 'object' && (
     this ?
       get() :
-      (Object.defineProperty(Object.prototype, '_T_', {
+      ($defineProperty($ObjectPrototype, '_T_', {
         configurable: true,
         get: get
       }), _T_)
   );
   function get() {
-    this.globalThis = this;
-    delete Object.prototype._T_;
+    $defineProperty(this, 'globalThis', {
+      value: this,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+    delete $ObjectPrototype._T_;
   }
 }(Object));
 module.exports = globalThis;

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,15 +1,31 @@
 (function (Object) {
+  var $ObjectPrototype = Object.prototype,
+    $defineGetter = $ObjectPrototype.__defineGetter__,
+    $defineProperty =
+      Object.defineProperty ||
+      function defineProperty(obj, prop, desc) {
+        if (desc.value) {
+          obj[prop] = desc.value;
+        } else if (desc.get) {
+          $defineGetter.call(obj, prop, desc.get);
+        }
+      };
   typeof globalThis !== 'object' && (
     this ?
       get() :
-      (Object.defineProperty(Object.prototype, '_T_', {
+      ($defineProperty($ObjectPrototype, '_T_', {
         configurable: true,
         get: get
       }), _T_)
   );
   function get() {
-    this.globalThis = this;
-    delete Object.prototype._T_;
+    $defineProperty(this, 'globalThis', {
+      value: this,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+    delete $ObjectPrototype._T_;
   }
 }(Object));
 export default globalThis;

--- a/index.js
+++ b/index.js
@@ -1,14 +1,30 @@
 (function (Object) {
+  var $ObjectPrototype = Object.prototype,
+    $defineGetter = $ObjectPrototype.__defineGetter__,
+    $defineProperty =
+      Object.defineProperty ||
+      function defineProperty(obj, prop, desc) {
+        if (desc.value) {
+          obj[prop] = desc.value;
+        } else if (desc.get) {
+          $defineGetter.call(obj, prop, desc.get);
+        }
+      };
   typeof globalThis !== 'object' && (
     this ?
       get() :
-      (Object.defineProperty(Object.prototype, '_T_', {
+      ($defineProperty($ObjectPrototype, '_T_', {
         configurable: true,
         get: get
       }), _T_)
   );
   function get() {
-    this.globalThis = this;
-    delete Object.prototype._T_;
+    $defineProperty(this, 'globalThis', {
+      value: this,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+    delete $ObjectPrototype._T_;
   }
 }(Object));

--- a/min.js
+++ b/min.js
@@ -1,1 +1,1 @@
-!function(t){function e(){this.globalThis=this,delete t.prototype._T_}"object"!=typeof globalThis&&(this?e():(t.defineProperty(t.prototype,"_T_",{configurable:!0,get:e}),_T_))}(Object);
+!function(e){var t=e.prototype,i=t.__defineGetter__,l=e.defineProperty||function(e,t,l){l.value?e[t]=l.value:l.get&&i.call(e,t,l.get)};function o(){l(this,"globalThis",{value:this,writable:!0,enumerable:!1,configurable:!0}),delete t._T_}"object"!=typeof globalThis&&(this?o():(l(t,"_T_",{configurable:!0,get:o}),_T_))}(Object);


### PR DESCRIPTION
This&nbsp;makes it&nbsp;so&nbsp;that the&nbsp;polyfilled `globalThis` is&nbsp;correctly&nbsp;non‑enumerable in&nbsp;**ES5+**&nbsp;engines.

This&nbsp;also required&nbsp;implementing a&nbsp;minimal `Object.defineProperty`&nbsp;shim for&nbsp;**ES3**&nbsp;environments.